### PR TITLE
Generate sidebar

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -45,7 +45,7 @@ const getSidebar = (rawSlug = "", first = true) => {
 		[[], []]
 	);
 
-	const index = indexContent ? { label, slug, badge: { text: "index", class: "badge" } } : [];
+	const index = indexContent ? { label, slug } : [];
 
 	const parsedFiles = files.map((file) => {
 		const content = readFile(`${path}/${file}`);

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,70 +1,113 @@
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
-
 import fs from "node:fs";
 
-const roots = fs
-  .readdirSync("src/content/docs")
-  .filter((v) => [".DS_Store", "index.md"].indexOf(v) === -1);
+const BOUNDRY_SLASHES_REGEX = /^\/|\/$/g;
+const TITLE_REGEX = /^-{3}\r?\ntitle:\s(?<tick>["'`])(?<title>.+)\k<tick>\s*\r?\n/;
+
+const BASE_PATH = "src/content/docs";
+
+const getMarkdownFileContent = (filePath) => {
+	if (!fs.existsSync(filePath)) {
+		return null;
+	}
+
+	return fs.readFileSync(filePath, "utf-8");
+};
+
+const getTitle = (markdownFileContent) => {
+	const match = markdownFileContent.match(TITLE_REGEX);
+
+	return match?.groups?.title ?? null;
+};
+
+const getSidebar = (rawSlug = "", collapseFirst = false) => {
+	const slug = rawSlug.replace(BOUNDRY_SLASHES_REGEX, "");
+	const path = `${BASE_PATH}/${slug}`;
+
+	const indexContent = getMarkdownFileContent(`${path}/index.md`);
+	const label = indexContent ? getTitle(indexContent) : slug.split("/").pop();
+
+	const index = indexContent ? { label, slug, badge: { text: "index", class: "badge" } } : [];
+
+	const [files, directories] = fs.readdirSync(path).reduce(
+		([files, directories], item) => {
+			const itemPath = `${path}/${item}`;
+
+			if (fs.lstatSync(itemPath).isDirectory()) {
+				return [files, [...directories, item]];
+			}
+
+			if (item === "index.md" || !item.endsWith(".md")) {
+				return [files, directories];
+			}
+
+			return [[...files, item], directories];
+		},
+		[[], []]
+	);
+
+	const parsedFiles = files.map((file) => {
+		const content = getMarkdownFileContent(`${path}/${file}`);
+		const title = getTitle(content);
+
+		return { label: title, slug: `${slug}/${file.replace(".md", "")}` };
+	});
+
+	const children = directories.map((directory) => getSidebar(`${slug}/${directory}`, true));
+
+	const items = [index, ...parsedFiles, ...children.flat()].flat();
+
+	return [{ label, collapsed: collapseFirst, items }];
+};
 
 // https://astro.build/config
 export default defineConfig({
-  site: "https://wiki.online.ntnu.no",
-  integrations: [
-    starlight({
-      title: "Online Wiki",
-      favicon: "/images/online_bla_o.svg",
-      defaultLocale: "root",
-      locales: {
-        root: {
-          label: "Norsk",
-          lang: "no",
-        },
-        en: {
-          label: "English",
-        },
-      },
-      logo: {
-        light: "./src/assets/img/online_bla_o.svg",
-        dark: "./src/assets/img/online_hvit_o.svg",
-      },
-      components: {
-        SocialIcons: './src/components/BekkLogo.astro',
-      },
-      lastUpdated: true,
-      customCss: ["./src/styles/custom.css"],
-      editLink: { baseUrl: "https://github.com/dotkom/wiki/edit/main/" },
+	site: "https://wiki.online.ntnu.no",
+	integrations: [
+		// https://starlight.astro.build/reference/configuration/
+		starlight({
+			title: "Online Wiki",
+			favicon: "/images/online_bla_o.svg",
+			defaultLocale: "root",
+			locales: {
+				root: {
+					label: "Norsk",
+					lang: "no",
+				},
+				en: {
+					label: "English",
+				},
+			},
+			logo: {
+				light: "./src/assets/img/online_bla_o.svg",
+				dark: "./src/assets/img/online_hvit_o.svg",
+			},
+			components: {
+				SocialIcons: "./src/components/BekkLogo.astro",
+			},
+			lastUpdated: true,
+			customCss: ["./src/styles/custom.css"],
+			editLink: { baseUrl: "https://github.com/dotkom/wiki/edit/main/" },
 
-      social: {
-        facebook: "https://facebook.com/LinjeforeningenOnline",
-        instagram: "https://www.instagram.com/online_ntnu/",
-        slack: "https://onlinentnu.slack.com/",
-        github: "https://github.com/dotkom/wiki",
-        discord: "https://discordapp.com/invite/2XB9egU",
-      },
-      head: [
-        {
-          tag: "script",
-          attrs: {
-            defer: true,
-            "data-domain": "wiki.online.ntnu.no",
-            src: "https://plausible.io/js/script.outbound-links.file-downloads.js",
-                    }
-                }
-            ],
-			sidebar: [
-        {
-					label: "Online",
-					link: "/",
-        },
-				...roots.map((root) => {
-					return {
-						label: root,
-						collapsed: true,
-						autogenerate: { directory: root },
-					};
-				}),
-      ],
-    }),
-  ],
+			social: {
+				facebook: "https://facebook.com/LinjeforeningenOnline",
+				instagram: "https://www.instagram.com/online_ntnu/",
+				slack: "https://onlinentnu.slack.com/",
+				github: "https://github.com/dotkom/wiki",
+				discord: "https://discordapp.com/invite/2XB9egU",
+			},
+			head: [
+				{
+					tag: "script",
+					attrs: {
+						"defer": true,
+						"data-domain": "wiki.online.ntnu.no",
+						"src": "https://plausible.io/js/script.outbound-links.file-downloads.js",
+					},
+				},
+			],
+			sidebar: getSidebar(),
+		}),
+	],
 });

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,7 +7,7 @@ const TITLE_REGEX = /^-{3}\r?\ntitle:\s(?<tick>["'`])(?<title>.+)\k<tick>\s*\r?\
 
 const BASE_PATH = "src/content/docs";
 
-const getMarkdownFileContent = (filePath) => {
+const readFile = (filePath) => {
 	if (!fs.existsSync(filePath)) {
 		return null;
 	}
@@ -25,7 +25,7 @@ const getSidebar = (rawSlug = "", first = true) => {
 	const slug = rawSlug.replace(BOUNDRY_SLASHES_REGEX, "");
 	const path = `${BASE_PATH}/${slug}`;
 
-	const indexContent = getMarkdownFileContent(`${path}/index.md`);
+	const indexContent = readFile(`${path}/index.md`);
 	const label = indexContent ? getTitle(indexContent) : slug.split("/").pop();
 
 	const [files, directories] = fs.readdirSync(path).reduce(
@@ -48,7 +48,7 @@ const getSidebar = (rawSlug = "", first = true) => {
 	const index = indexContent ? { label, slug, badge: { text: "index", class: "badge" } } : [];
 
 	const parsedFiles = files.map((file) => {
-		const content = getMarkdownFileContent(`${path}/${file}`);
+		const content = readFile(`${path}/${file}`);
 		const title = getTitle(content);
 
 		return { label: title, slug: `${slug}/${file.replace(".md", "")}` };

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -28,8 +28,6 @@ const getSidebar = (rawSlug = "", first = true) => {
 	const indexContent = getMarkdownFileContent(`${path}/index.md`);
 	const label = indexContent ? getTitle(indexContent) : slug.split("/").pop();
 
-	const index = indexContent ? { label, slug, badge: { text: "index", class: "badge" } } : [];
-
 	const [files, directories] = fs.readdirSync(path).reduce(
 		([files, directories], item) => {
 			const itemPath = `${path}/${item}`;
@@ -46,6 +44,8 @@ const getSidebar = (rawSlug = "", first = true) => {
 		},
 		[[], []]
 	);
+
+	const index = indexContent ? { label, slug, badge: { text: "index", class: "badge" } } : [];
 
 	const parsedFiles = files.map((file) => {
 		const content = getMarkdownFileContent(`${path}/${file}`);
@@ -93,7 +93,6 @@ export default defineConfig({
 			lastUpdated: true,
 			customCss: ["./src/styles/custom.css"],
 			editLink: { baseUrl: "https://github.com/dotkom/wiki/edit/main/" },
-
 			social: {
 				facebook: "https://facebook.com/LinjeforeningenOnline",
 				instagram: "https://www.instagram.com/online_ntnu/",

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,7 +3,7 @@ import starlight from "@astrojs/starlight";
 import fs from "node:fs";
 
 const BOUNDRY_SLASHES_REGEX = /^\/|\/$/g;
-const TITLE_REGEX = /^-{3}\r?\ntitle:\s(?<tick>["'`])(?<title>.+)\k<tick>\s*\r?\n/;
+const TITLE_REGEX = /^-{3}\r?\ntitle:\s(?<tick>["'`])(?<title>.+)\k<tick>\s*\r?\n-{3}/;
 
 const BASE_PATH = "src/content/docs";
 
@@ -21,7 +21,7 @@ const getTitle = (markdownFileContent) => {
 	return match?.groups?.title ?? null;
 };
 
-const getSidebar = (rawSlug = "", collapseFirst = false) => {
+const getSidebar = (rawSlug = "", first = true) => {
 	const slug = rawSlug.replace(BOUNDRY_SLASHES_REGEX, "");
 	const path = `${BASE_PATH}/${slug}`;
 
@@ -54,11 +54,15 @@ const getSidebar = (rawSlug = "", collapseFirst = false) => {
 		return { label: title, slug: `${slug}/${file.replace(".md", "")}` };
 	});
 
-	const children = directories.map((directory) => getSidebar(`${slug}/${directory}`, true));
+	const children = directories.map((directory) => getSidebar(`${slug}/${directory}`, false));
 
 	const items = [index, ...parsedFiles, ...children.flat()].flat();
 
-	return [{ label, collapsed: collapseFirst, items }];
+	if (first) {
+		return items;
+	}
+
+	return [{ label, collapsed: true, items }];
 };
 
 // https://astro.build/config

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -36,7 +36,7 @@ const getSidebar = (rawSlug = "", first = true) => {
 				return [files, [...directories, item]];
 			}
 
-			if (item === "index.md" || !item.endsWith(".md")) {
+			if (item === "index.md") {
 				return [files, directories];
 			}
 
@@ -51,7 +51,7 @@ const getSidebar = (rawSlug = "", first = true) => {
 		const content = readFile(`${path}/${file}`);
 		const title = getTitle(content);
 
-		return { label: title, slug: `${slug}/${file.replace(".md", "")}` };
+		return { label: title, slug: `${slug}/${file.replace(/\.mdx?/, "")}` };
 	});
 
 	const children = directories.map((directory) => getSidebar(`${slug}/${directory}`, false));

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -15,8 +15,8 @@ const readFile = (filePath) => {
 	return fs.readFileSync(filePath, "utf-8");
 };
 
-const getTitle = (markdownFileContent) => {
-	const match = markdownFileContent.match(TITLE_REGEX);
+const getTitle = (string) => {
+	const match = string.match(TITLE_REGEX);
 
 	return match?.groups?.title ?? null;
 };

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -56,7 +56,7 @@ const getSidebar = (rawSlug = "", first = true) => {
 
 	const children = directories.map((directory) => getSidebar(`${slug}/${directory}`, false));
 
-	const items = [index, ...parsedFiles, ...children.flat()].flat();
+	const items = [index, ...children.flat(), ...parsedFiles].flat();
 
 	if (first) {
 		return items;

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,7 +1,7 @@
-import { defineCollection } from 'astro:content';
-import { docsSchema, i18nSchema } from '@astrojs/starlight/schema';
+import { defineCollection } from "astro:content";
+import { docsSchema, i18nSchema } from "@astrojs/starlight/schema";
 
 export const collections = {
 	docs: defineCollection({ schema: docsSchema() }),
-	i18n: defineCollection({ type: "data", schema: i18nSchema() })
+	i18n: defineCollection({ type: "data", schema: i18nSchema() }),
 };

--- a/src/content/docs/generalforsamlingen/2011/index.md
+++ b/src/content/docs/generalforsamlingen/2011/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Generalforsamlingen 2011¶"
+title: "Generalforsamlingen 2011"
 ---
 
 * [2011 Hovedstyrets vedtektsforslag](/generalforsamlingen/2011/hs-vedtektsforslag) - Mange Onlinere har vært med å skrive dette forslaget til totalrevidering.

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -1,5 +1,5 @@
 /* Dark mode colors. */
-:root[data-theme="dark"] {
+:root {
 	--sl-color-accent-low: #162630;
 	--sl-color-accent: #327194;
 	--sl-color-accent-high: #b8ccd9;
@@ -10,7 +10,6 @@
 	--sl-color-gray-4: #5c5751;
 	--sl-color-gray-5: #3b3832;
 	--sl-color-gray-6: #2a2621;
-	--sl-color-gray-7: #1a1815;
 	--sl-color-black: #1a1815;
 }
 /* Light mode colors. */

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -27,14 +27,3 @@
 	--sl-color-gray-7: #f7f6f4;
 	--sl-color-black: #ffffff;
 }
-
-.badge {
-	background-color: transparent;
-	border-color: var(--sl-color-gray-5);
-	color: var(--sl-color-gray-3);
-}
-
-a[aria-current="page"] .badge {
-	border-color: var(--sl-color-accent-low);
-	color: var(--sl-color-accent-low);
-}

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -1,5 +1,5 @@
 /* Dark mode colors. */
-:root {
+:root[data-theme="dark"] {
 	--sl-color-accent-low: #162630;
 	--sl-color-accent: #327194;
 	--sl-color-accent-high: #b8ccd9;
@@ -10,10 +10,11 @@
 	--sl-color-gray-4: #5c5751;
 	--sl-color-gray-5: #3b3832;
 	--sl-color-gray-6: #2a2621;
+	--sl-color-gray-7: #1a1815;
 	--sl-color-black: #1a1815;
 }
 /* Light mode colors. */
-:root[data-theme='light'] {
+:root[data-theme="light"] {
 	--sl-color-accent-low: #cad9e3;
 	--sl-color-accent: #347396;
 	--sl-color-accent-high: #1b3645;
@@ -26,4 +27,15 @@
 	--sl-color-gray-6: #efedea;
 	--sl-color-gray-7: #f7f6f4;
 	--sl-color-black: #ffffff;
+}
+
+.badge {
+	background-color: transparent;
+	border-color: var(--sl-color-gray-5);
+	color: var(--sl-color-gray-3);
+}
+
+a[aria-current="page"] .badge {
+	border-color: var(--sl-color-accent-low);
+	color: var(--sl-color-accent-low);
 }


### PR DESCRIPTION
This PR changes:
- Sidebar groups uses their title instead of their slug as label
- Adds `index` label to index pages to easier differentiate between the group and the page

Before:
![image](https://github.com/user-attachments/assets/40b3da18-c646-4064-a385-b4c546f9cb07)

After:
![image](https://github.com/user-attachments/assets/a7070c02-583e-426b-af38-1478dc8769ee)
